### PR TITLE
Limit crud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem('dotenv-rails', require: 'dotenv/rails-now')
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.8'
   gem 'rubocop', '~> 0.81.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,11 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.12.2)
     ffi (1.12.2-java)
     ffi (1.12.2-x64-mingw32)
@@ -295,6 +300,7 @@ DEPENDENCIES
   coveralls
   devise
   dotenv-rails
+  factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 # ProductsController controls CRUD operations of the products
 class ProductsController < ApplicationController
+  before_action :authenticate_admin!, except: %i[show index]
   before_action :set_product, only: %i[show edit update destroy]
 
   # GET /products

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -4,5 +4,5 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   validates_presence_of :email, :password
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :timeoutable, timeout_in: 30.seconds
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,7 +1,6 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Books</h1>
-
 <br>
 
 <table>
@@ -24,8 +23,11 @@
     </tr>
     <tr>
       <td><%= link_to 'Read more', product %>
-      <%= link_to 'Edit', edit_product_path(product) %>
-      <%= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% if admin_signed_in? %>
+          <%= link_to 'Edit', edit_product_path(product) %>
+          <%= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' } %>
+        <% end %>
+        </td>
     </tr>
     <tr>
       <td>
@@ -37,5 +39,6 @@
 </table>
 
 <br>
-
-<%= link_to 'New Product', new_product_path %>
+<% if admin_signed_in? %>
+  <%= link_to 'New Product', new_product_path %>
+<% end %>

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -24,6 +24,15 @@ require('rails_helper')
 # `rails-controller-testing` gem.
 
 RSpec.describe(ProductsController, type: :controller) do
+  before do
+    admin = FactoryBot.create(:admin)
+    sign_in_admin(admin)
+  end
+
+  def sign_in_admin(admin)
+    sign_in admin
+  end
+
   # This should return the minimal set of attributes required to create a valid
   # Product. As you add validations to Product, be sure to
   # adjust the attributes here as well.

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin, class: 'Admin' do
+    email { 'random@example.com' }
+    password { 'random@123' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,10 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
+  config.include Devise::Test::ControllerHelpers, type: :view
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/views/products/index.html.erb_spec.rb
+++ b/spec/views/products/index.html.erb_spec.rb
@@ -57,4 +57,31 @@ RSpec.describe('products/index', type: :view) do
     assert_select 'tr>td', text: 'Library: Library'.to_s, count: 2
     assert_select 'tr>td', text: 'Adoption amount: ' + number_to_currency('1500.39', strip_insignificant_zeros: true), count: 2
   end
+
+  context 'when admin is not logged in' do
+    it 'should not allow admin to see edit, delete and new product links' do
+      render
+      expect(rendered).to have_no_link('Edit')
+      expect(rendered).to have_no_link('Destroy')
+      expect(rendered).to have_no_link('New Product')
+    end
+  end
+
+  context 'when admin is logged in' do
+    before(:each) do
+      admin = FactoryBot.create(:admin)
+      sign_in_admin(admin)
+    end
+
+    def sign_in_admin(admin)
+      sign_in admin
+    end
+
+    it 'should allow admin to see edit, delete and new product links' do
+      render
+      expect(rendered).to have_link('Edit', count: 2)
+      expect(rendered).to have_link('Destroy', count: 2)
+      expect(rendered).to have_link('New Product', count: 1)
+    end
+  end
 end


### PR DESCRIPTION
- Limited Create, Edit, Update and Delete to logged in admin Users.
- Disabled view of CRUD buttons from UI.
- Have used timeout in devise and have set that to 30 seconds for now to test which will later be 8 hours after which admin users lose their session and have to log in again to do admin related stuff.
- Have modified specs to incorporate devise and access changes. Have used FactoryBot.

So now, loggedIn admin users will see CRUD products page and general users will see just the index and show pages.