### PR TITLE
Fixes #34: Status based product page

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,11 @@ class ProductsController < ApplicationController
   # GET /products
   # GET /products.json
   def index
-    @products = Product.all
+    @products = if Product.adopt_statuses.key? params['status'] # security check that it's a valid param
+                  Product.send(params['status'])
+                else
+                  Product.available # if not a valid status param, just return available products
+                end
   end
 
   # GET /products/1

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,2 +1,4 @@
+# Product model describes model attributes of products
 class Product < ApplicationRecord
+  enum adopt_status: %i[available adopted pending]
 end

--- a/app/views/cart/index.html.erb
+++ b/app/views/cart/index.html.erb
@@ -5,7 +5,7 @@
   <h1>Adoption cart</h1>
   <% if @cart.empty? %>
     <p>The cart is empty.</p>
-    <%= link_to 'Adopt more books', products_path %>
+    <%= link_to 'Adopt books', status_products_path(:status => "available") %>
   <% else %>
     <% @cart.each do |product| %>
       <h4><b><%= product.title %></b><div style="float:right"><%= number_to_currency(product.adopt_amount, strip_insignificant_zeros: true) %></div></h4>
@@ -25,7 +25,7 @@
     <div style="float:right">Total price: <%= number_to_currency(@cart.map(&:adopt_amount).sum, strip_insignificant_zeros: true) %></div>
     <br />
     <%= link_to 'Clear cart', cart_path, remote: true, method: :delete, data: { confirm: 'Are you sure?' } %>
-    <%= link_to 'Adopt more books', products_path %>
+    <%= link_to 'Adopt more books', status_products_path(:status => "available") %>
     <%= submit_tag "Checkout"%>
   <% end %>
 <% end %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -53,7 +53,7 @@
 
   <div class="field">
     <%= form.label :adopt_status %>
-    <%= form.number_field :adopt_status %>
+    <%= form.text_field :adopt_status, :value => product.adopt_status.capitalize  %>
   </div>
 
   <div class="field">

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', product: @product %>
 
 <%= link_to 'Show', @product %> |
-<%= link_to 'Back', products_path %>
+<%= link_to 'Back', status_products_path(:status => @product.adopt_status) %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', product: @product %>
 
-<%= link_to 'Back', products_path %>
+<%= link_to 'Back', status_products_path(:status => "available") %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -44,7 +44,7 @@
 
 <p>
   <strong>Adopt status:</strong>
-  <%= @product.adopt_status %>
+  <%= @product.adopt_status.capitalize %>
 </p>
 
 <p>
@@ -105,7 +105,7 @@
   <p>
     <a>Added to cart</a>
     <%= link_to 'View cart', cart_path %>
-    <%= link_to 'Adopt more books', products_path %>
+    <%= link_to 'Adopt more books', status_products_path(:status => "available") %>
   </p>
 <% else %>
   <p><%= link_to 'Add to cart', @product, remote: true, method: :post %></p>
@@ -114,4 +114,4 @@
 <% if admin_signed_in? %>
   <%= link_to 'Edit', edit_product_path(@product) %> |
 <% end %>
-<%= link_to 'Back', products_path %>
+<%= link_to 'Back', status_products_path(:status => @product.adopt_status) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
   post 'cart', to: 'cart#checkout'
   delete 'cart', to: 'cart#destroy'
   devise_for :admins, path: '', path_names: { sign_in: 'login', sign_out: 'logout', sign_up: 'register' }
-  resources :products
+  resources :products, except: [:index] do
+    collection do
+      get 'status/:status', to: 'products#index', as: 'status'
+    end
+  end
   root 'products#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe(ProductsController, type: :controller) do
       library: 'Library',
       description: 'Description',
       condition_treatment: 'Condition Treatment',
-      adopt_status: 2,
+      adopt_status: 'pending',
       adopt_amount: '1500.39',
       release_year: 2020,
       dedication: 'Dedication',
@@ -66,9 +66,24 @@ RSpec.describe(ProductsController, type: :controller) do
   let(:valid_session) { {} }
 
   describe 'GET #index' do
-    it 'returns a success response' do
-      get :index, params: {}, session: valid_session
-      expect(response).to(be_successful)
+    context 'when status is available' do
+      it 'returns a success response for available books' do
+        get :index, params: { status: 'available' }, session: valid_session
+        expect(@product.adopt_status).to(eq('available'))
+        expect(response).to(be_successful)
+      end
+    end
+
+    context 'when status is adopted' do
+      before do
+        @product = FactoryBot.create(:adopted_product)
+      end
+
+      it 'returns a success response for adopted books' do
+        get :index, params: { status: 'adopted' }, session: valid_session
+        expect(@product.adopt_status).to(eq('adopted'))
+        expect(response).to(be_successful)
+      end
     end
   end
 
@@ -127,7 +142,7 @@ RSpec.describe(ProductsController, type: :controller) do
           library: 'Library New',
           description: 'Description New',
           condition_treatment: 'Condition Treatment New',
-          adopt_status: 1,
+          adopt_status: 'adopted',
           adopt_amount: '2500.99',
           release_year: 2020,
           dedication: 'Dedication New',
@@ -146,7 +161,7 @@ RSpec.describe(ProductsController, type: :controller) do
         expect(@product.library).to(have_content('Library New'))
         expect(@product.description).to(have_content('Description New'))
         expect(@product.condition_treatment).to(have_content('Condition Treatment New'))
-        expect(@product.adopt_status).to(have_content(1))
+        expect(@product.adopt_status).to(have_content('adopted'))
         expect(@product.adopt_amount).to(have_content('2500.99'))
         expect(@product.release_year).to(have_content(2020))
         expect(@product.dedication).to(eq('Dedication New'))

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -10,7 +10,23 @@ FactoryBot.define do
     library { 'Library' }
     description { 'Description' }
     condition_treatment { 'Condition Treatment' }
-    adopt_status { 2 }
+    adopt_status { 'available' }
+    adopt_amount { '1500.39' }
+    release_year { 2020 }
+    dedication { 'Dedication' }
+    recognition { 'Recognition' }
+  end
+
+  factory :adopted_product, class: 'Product' do
+    title { 'Title' }
+    author { 'Author' }
+    pub_year { 'Pub Year' }
+    category { 'Category' }
+    image { 'Image' }
+    library { 'Library' }
+    description { 'Description' }
+    condition_treatment { 'Condition Treatment' }
+    adopt_status { 'adopted' }
     adopt_amount { '1500.39' }
     release_year { 2020 }
     dedication { 'Dedication' }

--- a/spec/requests/cart_spec.rb
+++ b/spec/requests/cart_spec.rb
@@ -1,0 +1,10 @@
+require('rails_helper')
+
+RSpec.describe('Cart', type: :request) do
+  describe 'GET /cart' do
+    it 'works!' do
+      get cart_path
+      expect(response).to(have_http_status(200))
+    end
+  end
+end

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -1,9 +1,9 @@
 require('rails_helper')
 
 RSpec.describe('Products', type: :request) do
-  describe 'GET /products' do
-    it 'works! (now write some real specs)' do
-      get products_path
+  describe 'GET /products/status/0' do
+    it 'works!' do
+      get status_products_path(status: 0)
       expect(response).to(have_http_status(200))
     end
   end

--- a/spec/routing/cart_routing_spec.rb
+++ b/spec/routing/cart_routing_spec.rb
@@ -1,0 +1,9 @@
+require('rails_helper')
+
+RSpec.describe(CartController, type: :routing) do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/cart').to(route_to('cart#index'))
+    end
+  end
+end

--- a/spec/routing/products_routing_spec.rb
+++ b/spec/routing/products_routing_spec.rb
@@ -3,7 +3,7 @@ require('rails_helper')
 RSpec.describe(ProductsController, type: :routing) do
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: '/products').to(route_to('products#index'))
+      expect(get: '/products/status/0').to(route_to('products#index', 'status' => '0'))
     end
 
     it 'routes to #new' do

--- a/spec/views/cart/index.html.erb_spec.rb
+++ b/spec/views/cart/index.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe('cart/index', type: :view) do
     it 'renders attributes in <p>' do
       render
       expect(rendered).to(match(/The cart is empty./))
-      expect(rendered).to have_link('Adopt more books')
+      expect(rendered).to have_link('Adopt books')
     end
   end
 

--- a/spec/views/products/index.html.erb_spec.rb
+++ b/spec/views/products/index.html.erb_spec.rb
@@ -5,13 +5,31 @@ RSpec.describe('products/index', type: :view) do
     @products = FactoryBot.create_list(:product, 2)
   end
 
-  it 'renders a list of products' do
-    render
-    assert_select 'tr>td', text: 'Title: Title'.to_s, count: 2
-    assert_select 'tr>td', text: 'Author: Author'.to_s, count: 2
-    assert_select 'tr>td', text: 'Category: Category'.to_s, count: 2
-    assert_select 'tr>td', text: 'Library: Library'.to_s, count: 2
-    assert_select 'tr>td', text: 'Adoption amount: ' + number_to_currency('1500.39', strip_insignificant_zeros: true), count: 2
+  context 'for available books with status is available' do
+    before do
+      @products = Product.send('available')
+    end
+    it 'renders a list of products' do
+      render
+      assert_select 'tr>td', text: 'Title: Title'.to_s, count: 2
+      assert_select 'tr>td', text: 'Author: Author'.to_s, count: 2
+      assert_select 'tr>td', text: 'Category: Category'.to_s, count: 2
+      assert_select 'tr>td', text: 'Library: Library'.to_s, count: 2
+      assert_select 'tr>td', text: 'Adoption amount: ' + number_to_currency('1500.39', strip_insignificant_zeros: true), count: 2
+    end
+  end
+
+  context 'for adopted books with status is adopted' do
+    before do
+      @products = Product.send('adopted')
+    end
+    it 'renders a list of products' do
+      render
+      assert_select 'tr>td', text: 'Title: Title'.to_s, count: 0
+      assert_select 'tr>td', text: 'Author: Author'.to_s, count: 0
+      assert_select 'tr>td', text: 'Category: Category'.to_s, count: 0
+      assert_select 'tr>td', text: 'Library: Library'.to_s, count: 0
+    end
   end
 
   context 'when admin is not logged in' do

--- a/spec/views/products/show.html.erb_spec.rb
+++ b/spec/views/products/show.html.erb_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe('products/show', type: :view) do
       expect(rendered).to(match(/2020/))
       expect(rendered).to(match(/Added to cart/))
       expect(rendered).to have_link('View cart', href: cart_path)
-      expect(rendered).to have_link('Adopt more books', href: products_path)
+      expect(rendered).to have_link('Adopt more books', href: status_products_path(status: 'available'))
       expect(rendered).to have_no_link('Add to cart')
     end
   end


### PR DESCRIPTION
Routes:
products/status/0: renders available books page
products/status/1: renders adopted books page

Renders available books page by default since it's the root path right now. Will change that accordingly in future since that's not required.

Wrote specs for page rendering and response for available and adopted books page