### PR TITLE
Fix #35: Cart alert and expiry

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,4 +5,4 @@ UC_FOUNDATION_MAIL_ADDRESS=fake-foundation@uc.edu
 
 #Expiration time variables (in minutes)
 ADMIN_EMPIRY_TIME=480
-CART_EXPIRY_TIME=3
+CART_EXPIRY_TIME=30

--- a/.env.test
+++ b/.env.test
@@ -5,4 +5,4 @@ UC_FOUNDATION_MAIL_ADDRESS=fake-foundation@uc.edu
 
 #Expiration time variables (in minutes)
 ADMIN_EMPIRY_TIME=480
-CART_EXPIRY_TIME=3
+CART_EXPIRY_TIME=30

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,11 @@ gem('jbuilder', '~> 2.5')
 
 # Reduces boot times through caching; required in config/boot.rb
 gem('bootsnap', '>= 1.1.0', require: false)
+gem 'bootstrap'
 gem 'devise'
 gem('dotenv-rails', require: 'dotenv/rails-now')
+gem 'jquery-rails'
+gem 'jquery-ui-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (10.0.1.0)
+      execjs
     bcrypt (3.1.16)
     bcrypt (3.1.16-java)
     bindex (0.8.1)
@@ -55,6 +57,10 @@ GEM
       msgpack (~> 1.0)
     bootsnap (1.4.6-java)
       msgpack (~> 1.0)
+    bootstrap (4.0.0)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.4)
     byebug (11.1.1)
     capybara (3.32.0)
@@ -116,6 +122,12 @@ GEM
     jaro_winkler (1.5.4-java)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     json (2.3.0)
     json (2.3.0-java)
     listen (3.1.5)
@@ -151,6 +163,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
+    popper_js (1.16.0)
     public_suffix (4.0.3)
     puma (3.12.4)
     puma (3.12.4-java)
@@ -299,6 +312,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap
   byebug
   capybara (>= 2.15)
   chromedriver-helper
@@ -308,6 +322,8 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.5)
+  jquery-rails
+  jquery-ui-rails
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,9 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+//= require jquery3
+//= require jquery-ui
+//= require jquery_ujs
+//= require popper
+//= require bootstrap
+//= stub 'cart_expiry'

--- a/app/assets/javascripts/cart_expiry.js
+++ b/app/assets/javascripts/cart_expiry.js
@@ -1,0 +1,33 @@
+const cart_expiry_time = 30
+const confirm_dialog_time = 25
+
+var timeoutIds = [];
+
+document.addEventListener('turbolinks:load', function() {
+  clearPreviousExpirationTime();
+  setExpirationTime();
+
+  $('#myModal').on('click','.btn-primary', function() {
+    // Reloading the same page to keep the session active
+    location.reload();
+
+    $('#myModal').modal('hide');
+  });
+
+  function clearPreviousExpirationTime() {
+    for(i = 0; i < timeoutIds.length; i++){
+        window.clearTimeout(timeoutIds[i]);
+    }
+  }
+  function setExpirationTime() {
+    var sessionExpiry = window.setTimeout(function() {
+      window.location.href = '/';
+    }, cart_expiry_time * 60 * 1000);
+
+    var confirmdialog = window.setTimeout(function() {
+      $('#myModal').modal();
+    }, confirm_dialog_time * 60 * 1000);
+
+    timeoutIds = [sessionExpiry, confirmdialog];
+  }
+})

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,5 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require_self
  */
+@import "bootstrap";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,13 +12,9 @@ class ApplicationController < ActionController::Base
   def check_session_expiry
     if !session[:expires_at].nil? && (session[:expires_at] < Time.now)
       Product.where(id: session[:cart].keys).update_all(adopt_status: Product.adopt_statuses[:available])
-      reset_session
+      %i[cart expires_at].each { |x| session.delete(x) }
     else
       session[:expires_at] = ENV['CART_EXPIRY_TIME'].to_i.minutes.from_now
     end
-  end
-
-  def cart_session_exists?
-    redirect_to root_path, alert: 'Session expired!' if session[:cart].nil?
   end
 end

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,7 +1,6 @@
 # CartController manages cart session for every adopter
 class CartController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :cart_session_exists?
   before_action :set_cart, only: %i[index checkout]
   before_action :set_adopter
 
@@ -16,7 +15,7 @@ class CartController < ApplicationController
 
   def destroy
     Product.where(id: session[:cart].keys).update_all(adopt_status: Product.adopt_statuses[:available])
-    %i[cart expires_at visit_count].each { |x| session.delete(x) }
+    %i[cart expires_at].each { |x| session.delete(x) }
     redirect_to root_path
   end
 
@@ -40,7 +39,7 @@ class CartController < ApplicationController
       Product.find(id).update(adopter_id: @adopter.id, adopt_status: Product.adopt_statuses[:pending], adopt_time: Time.now, dedication: session[:cart][id]['dedication'], recognition: session[:cart][id]['recognition'])
     end
     send_emails
-    %i[cart expires_at visit_count].each { |x| session.delete(x) }
+    %i[cart expires_at].each { |x| session.delete(x) }
     redirect_to root_path, notice: 'Adopt success!'
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,8 +2,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_admin!, except: %i[show index add]
   before_action :set_product, only: %i[show edit update destroy]
-  before_action :cart_session_exists?, only: :add
-  # skip_before_action :verify_authenticity_token, only: :action?
+  skip_before_action :verify_authenticity_token
   # GET /products
   # GET /products.json
   def index

--- a/app/views/layouts/_cart_expiry_confirm.html.erb
+++ b/app/views/layouts/_cart_expiry_confirm.html.erb
@@ -1,0 +1,13 @@
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        Your session will expire in 10 minutes due to inactivity. Please click OK to extend your session for another 30 minutes.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,13 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <% unless admin_signed_in? %>
+      <%= javascript_include_tag 'cart_expiry'%>
+    <% end %>
   </head>
 
   <body>
     <%= yield %>
+    <%= render "layouts/cart_expiry_confirm.html.erb" %>
   </body>
 </html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[cart_expiry.js]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   post 'products/:id', to: 'products#add'
   delete 'cart/:id', to: 'cart#remove', as: 'remove'
   get 'cart', to: 'cart#index'
-  post 'cart/checkout', to: 'cart#checkout', as: 'checkout'
+  match 'cart/checkout' => 'cart#checkout', as: 'checkout', via: %i[get post]
   post 'cart/payment', to: 'cart#payment', as: 'payment'
   delete 'cart', to: 'cart#destroy'
   devise_for :admins, path: '', path_names: { sign_in: 'login', sign_out: 'logout', sign_up: 'register' }


### PR DESCRIPTION
- After 25 minutes (now its 1 minute) of inactivity (no actions performed), custom bootstrap modal pops up with ok and cancel button.

- On click of OK, session gets extended to another 30 minutes(3 minutes now). On click of cancel, session expires in 30 minutes if no action is invoked in between. If no action is performed, session resets every 30 minutes.

- This is based on user session. So, have changed the messaged to 'Your session' instead of 'Your shopping cart'. Please see the image for the message.

![image](https://user-images.githubusercontent.com/57577808/101228998-27617b80-366c-11eb-82e0-75028555b9d5.png)

- Admin's session stays for 8 hours with no interruption by this alert or session.

- If a book is added to cart and then the browser itself is closed, the book will not be available for other users unless this browser is opened again. Please let me know if that should be handled. I thought of options but couldn't find a solution. One way I thought would work is running a rake task everyday at midnight or after midnight (2 or 3 AM) when traffic would be low. The rake task will put all pending books with no author to available state.

- I have added bootstrap to the application because of which fonts have changed which I will take care in 'css and layouts' issue.

Please let me know if there are other things to consider.