### PR TITLE
Admin related changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/MethodLength:
     Max: 1000
 
 Metrics/BlockLength:
-    Max: 150
+    Max: 200
 
 Metrics/AbcSize:
     Max: 30

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,5 +16,5 @@
 @import "bootstrap";
 
 .main-content {
-  min-height: 60vh;
+  min-height: 62vh;
 }

--- a/app/assets/stylesheets/layouts.scss
+++ b/app/assets/stylesheets/layouts.scss
@@ -63,4 +63,13 @@ footer {
   #links {
     font-weight: 600;
   }
+
+  #login {
+    float: right;
+    padding-top: 10px;
+    p {
+      margin: 10px;
+      font-size: 16px;
+    }
+  }
 }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -122,6 +122,11 @@ div {
 
 .link {
   color: #046B99;
+  margin-right: 15px;
+  &:hover {
+    color: #000;
+    text-decoration: none;
+  }
 }
 
 .product-title {
@@ -129,6 +134,11 @@ div {
   font-size: 16px;
   font-weight: bold;
   padding-bottom: 3px;
+
+  &:hover {
+    color: #000;
+    text-decoration: none;
+  }
 }
 
 .bookplate-readmore {
@@ -150,9 +160,9 @@ div {
 }
 
 .btn.btn-default {
+  margin-right: 30px;
   background-color: black;
   color: white;
-  margin: 4px 2px;
   border-radius: 4px;
 
   &:hover {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,9 @@ class ApplicationController < ActionController::Base
       session[:expires_at] = ENV['CART_EXPIRY_TIME'].to_i.minutes.from_now
     end
   end
+
+  # Overwriting the sign_out redirect path method
+  def after_sign_out_path_for(_resource)
+    new_admin_session_path
+  end
 end

--- a/app/views/cart/checkout.html.erb
+++ b/app/views/cart/checkout.html.erb
@@ -60,7 +60,7 @@
     </div>
     <div class="mt-2">
       <%= label_tag 'Phone*' %>
-      <%= number_field_tag 'phone', nil, required: true, class: 'form-input', pattern: '[0-9]{3}-[0-9]{3}-[0-9]{4}' %>
+      <%= phone_field_tag 'phone', nil, required: true, class: 'form-input', pattern: '[0-9]{3}-[0-9]{3}-[0-9]{4}' %>
       Format: 123-456-7890
     </div><br />
     <div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,11 +13,49 @@
   </div>
   <div id="header-bottom">
     <div class="container">
-      <div class="row">
-        <div id="logo" class="col-3">
-          <%= link_to image_tag('logo.png'), root_path %>
+      <% unless admin_signed_in? %>
+        <div class="row">
+          <div id="logo" class="col-3">
+            <%= link_to image_tag('logo.png'), root_path %>
+          </div>
+
+          <div id="links" class="col-8">
+              <nav class="navbar">
+                <ul class="nav justify-content-center">
+                  <li class="nav-item">
+                    <%= link_to 'Available Books', status_products_path(:status => 'available'), :class => 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'Adopted Books', status_products_path(:status => 'adopted'), :class => 'nav-link' %>
+                  <li>
+                  <li class="nav-item">
+                    <%= link_to 'Event', '/', :class => 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'Donors', '/', :class => 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'Contact', '/', :class => 'nav-link' %>
+                  </li>
+              </nav>
+          </div>
+
+          <div class="col-1">
+            <nav class="navbar">
+              <%= link_to image_tag('cart.png'), cart_path %>
+              <% unless session[:cart].blank? %>
+                <%= link_to session[:cart].keys.count, cart_path, class: 'btn btn-circle' %>
+              <% end %>
+            </nav>
+          </div>
         </div>
-        <div id="links" class="col-8">
+      <% else %>
+        <div class="row">
+          <div id="logo" class="col-3">
+            <%= link_to image_tag('logo.png'), root_path %>
+          </div>
+
+          <div id="links" class="col-9">
             <nav class="navbar">
               <ul class="nav justify-content-center">
                 <li class="nav-item">
@@ -25,6 +63,9 @@
                 </li>
                 <li class="nav-item">
                   <%= link_to 'Adopted Books', status_products_path(:status => 'adopted'), :class => 'nav-link' %>
+                <li>
+                <li class="nav-item">
+                  <%= link_to 'Pending Books', status_products_path(:status => 'pending'), :class => 'nav-link' %>
                 <li>
                 <li class="nav-item">
                   <%= link_to 'Event', '/', :class => 'nav-link' %>
@@ -36,16 +77,14 @@
                   <%= link_to 'Contact', '/', :class => 'nav-link' %>
                 </li>
             </nav>
+          </div>
         </div>
-        <div class="col-1">
-          <nav class="navbar">
-            <%= link_to image_tag('cart.png'), cart_path %>
-            <% unless session[:cart].blank? %>
-              <%= link_to session[:cart].keys.count, cart_path, class: 'btn btn-circle' %>
-            <% end %>
-          </nav>
+
+        <div id="login" class="row">
+          <p>Logged in as <%= current_admin.email %></p>
+          <%= link_to "Logout", destroy_admin_session_path, :method => :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default' %>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,13 @@
   <body>
     <div class="wrapper">
       <%= render "layouts/header.html.erb" %>
-      <br>
+      <br><br>
       <div class="main-content container">
-        <p id="notice"><%= notice %></p>
+        <% if alert %>
+          <p id="alert" style="color: red"><%= alert %></p>
+        <% elsif notice %>
+          <p id="notice"><%= notice %></p>
+        <% end %>
         <%= yield %>
       </div>
       <br>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -53,7 +53,7 @@
 
   <div class="field">
     <%= form.label :adopt_status %>
-    <%= form.text_field :adopt_status, :value => product.adopt_status.capitalize  %>
+    <%= form.text_field :adopt_status, :value => product.adopt_status %>
   </div>
 
   <div class="field">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,61 +1,58 @@
-<% if admin_signed_in? && current_admin %>
-    <p>Logged in as <%= current_admin.email %>
-    <%= link_to "Logout", destroy_admin_session_path, :method => :delete, data: { confirm: 'Are you sure?' } %></p>
-<% end %>
-
 <h3 id="heading"><%= @adopt_status.capitalize %> books</h3><br>
 
 <% unless @products.blank? %>
   <% @products.each do |product| %>
   <div class="row">
-      <div class="col-3">
-        <%# Replace with @product.title in place of sample_image.jpg when all images are available %>
-        <%= link_to (image_tag 'sample_image.jpg', width: '130', height: '170', class: 'book-image'), product %>
-      </div>
-      <div  class="col-9">
-        <table>
-          <tbody>
-              <tr>
-                <td><%= link_to product.title, product, class: 'product-title' %></td>
-              </tr>
-              <tr>
-                <td></td>
-              </tr>
-              <tr>
-                <td><strong>Adoption amount: </strong><%= number_to_currency(product.adopt_amount, strip_insignificant_zeros: true) %></td>
-              </tr>
-              <tr>
-                <td><strong>Author: </strong><%= product.author %></td>
-              </tr>
-              <tr>
-                <td><strong>Category: </strong><%= product.category %></td>
-              </tr>
-              <tr>
-                <td><strong>Library: </strong><%= product.library %></td>
-              </tr>
-              <tr>
-                <td><%= link_to 'Read more', product, class: 'link' %>
-                  <% if admin_signed_in? %>
-                    <%= link_to 'Edit', edit_product_path(product) %>
-                    <%= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' } %>
-                  <% end %>
-                  </td>
-              </tr>
-          </tbody>
-        </table>
-      </div>
+    <div class="col-3">
+      <%# Replace with @product.title in place of sample_image.jpg when all images are available %>
+      <%= link_to (image_tag 'sample_image.jpg', width: '130', height: '170', class: 'book-image'), product %>
     </div>
-    <br><br>
-  <% end %>
+    <div  class="col-9">
+      <table>
+        <tbody>
+            <tr>
+              <td><%= link_to product.title, product, class: 'product-title' %></td>
+            </tr>
+            <tr>
+              <td></td>
+            </tr>
+            <tr>
+              <td><strong>Adoption amount: </strong><%= number_to_currency(product.adopt_amount, strip_insignificant_zeros: true) %></td>
+            </tr>
+            <tr>
+              <td><strong>Author: </strong><%= product.author %></td>
+            </tr>
+            <tr>
+              <td><strong>Category: </strong><%= product.category %></td>
+            </tr>
+            <tr>
+              <td><strong>Library: </strong><%= product.library %></td>
+            </tr>
+            <tr>
+              <td><%= link_to 'Read more', product, class: 'link' %>
+                <% if admin_signed_in? %>
+                  <%= link_to 'Edit', edit_product_path(product), class: 'link' %>
+                  <% if product.available? %>
+                    <%= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' }, class: 'link' %>
+                  <% end %>
+                <% end %>
+                </td>
+            </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <br><br>
+<% end %>
 <% else %>
   <p> No books found.  </p>
 <% end %>
 
+<% if admin_signed_in? && @adopt_status == 'available' %>
+  <%= link_to 'New Product', new_product_path, class: 'btn btn-default' %>
+<% end %>
+<br>
+
 <% unless @products.blank? %>
   <%= pagy_bootstrap_nav(@pagy).html_safe %>
-<% end %>
-
-<br>
-<% if admin_signed_in? %>
-  <%= link_to 'New Product', new_product_path %>
 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -139,7 +139,7 @@
       <%= link_to 'View cart', cart_path, class: 'btn btn-default'%>
       <%= link_to 'Adopt more books', status_products_path(:status => "available"), class: 'btn btn-default' %>
     </p>
-  <% elsif @product.available? %>
+  <% elsif @product.available? && !admin_signed_in? %>
     <%= link_to 'Add to cart', @product, remote: true, method: :post, class: "btn btn-default" %>
   <% end %>
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe ApplicationController, type: :controller do
       expect(session).to be_empty
     end
   end
+
+  describe 'logout' do
+    before do
+      @admin = FactoryBot.create(:admin)
+    end
+    it 'redirects to admin login page' do
+      expect(@controller.instance_eval { after_sign_out_path_for(@admin) }).to eq new_admin_session_path
+    end
+  end
 end

--- a/spec/views/products/index.html.erb_spec.rb
+++ b/spec/views/products/index.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe('products/index', type: :view) do
     @adopt_status = 'available'
   end
 
-  context 'for available books with status is available' do
+  context 'for available books' do
     before do
       @pagy, @products = pagy(Product.send('available'), items: ENV['ITEMS_PER_PAGE'])
       @adopt_status = 'available'
@@ -24,17 +24,33 @@ RSpec.describe('products/index', type: :view) do
     end
   end
 
-  context 'for adopted books with status is adopted' do
+  context 'for adopted books' do
     before do
+      FactoryBot.create_list(:adopted_product, 2)
       @pagy, @products = pagy(Product.send('adopted'), items: ENV['ITEMS_PER_PAGE'])
       @adopt_status = 'adopted'
     end
     it 'renders a list of products' do
       render
-      assert_select 'tr>td', text: 'Title: Title'.to_s, count: 0, href: @product
-      assert_select 'tr>td', text: 'Author: Author'.to_s, count: 0
-      assert_select 'tr>td', text: 'Category: Category'.to_s, count: 0
-      assert_select 'tr>td', text: 'Library: Library'.to_s, count: 0
+      assert_select 'tr>td', text: 'Title'.to_s, count: 2, href: @product
+      assert_select 'tr>td', text: 'Author: Author'.to_s, count: 2
+      assert_select 'tr>td', text: 'Category: Category'.to_s, count: 2
+      assert_select 'tr>td', text: 'Library: Library'.to_s, count: 2
+    end
+  end
+
+  context 'for pending books' do
+    before do
+      FactoryBot.create_list(:pending_product, 2)
+      @pagy, @products = pagy(Product.send('pending'), items: ENV['ITEMS_PER_PAGE'])
+      @adopt_status = 'pending'
+    end
+    it 'renders a list of products' do
+      render
+      assert_select 'tr>td', text: 'Title'.to_s, count: 2, href: @product
+      assert_select 'tr>td', text: 'Author: Author'.to_s, count: 2
+      assert_select 'tr>td', text: 'Category: Category'.to_s, count: 2
+      assert_select 'tr>td', text: 'Library: Library'.to_s, count: 2
     end
   end
 
@@ -57,31 +73,55 @@ RSpec.describe('products/index', type: :view) do
     end
   end
 
-  context 'when admin is logged in' do
-    before(:each) do
-      admin = FactoryBot.create(:admin)
-      sign_in_admin(admin)
+  describe 'when admin is logged in' do
+    context 'product is available' do
+      before(:each) do
+        admin = FactoryBot.create(:admin)
+        sign_in_admin(admin)
+      end
+
+      def sign_in_admin(admin)
+        sign_in admin
+      end
+
+      it 'should allow admin to see edit link' do
+        render
+        expect(rendered).to have_link('Edit', count: 2)
+      end
+
+      it 'should allow admin to see new product and destroy links' do
+        render
+        expect(rendered).to have_link('Destroy', count: 2)
+        expect(rendered).to have_link('New Product', href: new_product_path, count: 1)
+      end
     end
 
-    def sign_in_admin(admin)
-      sign_in admin
+    context 'product is adopted' do
+      before do
+        FactoryBot.create_list(:adopted_product, 2)
+        @pagy, @products = pagy(Product.send('adopted'), items: ENV['ITEMS_PER_PAGE'])
+        @adopt_status = 'adopted'
+      end
+
+      it 'should not allow admin to see new product and destroy links when the product is adopted' do
+        render
+        expect(rendered).to have_no_link('Destroy')
+        expect(rendered).to have_no_link('New Product')
+      end
     end
 
-    it 'should allow admin to see edit, delete and new product links' do
-      render
-      expect(rendered).to have_link('Edit', count: 2)
-      expect(rendered).to have_link('Destroy', count: 2)
-      expect(rendered).to have_link('New Product', href: new_product_path, count: 1)
-    end
+    context 'product is pending' do
+      before do
+        FactoryBot.create_list(:pending_product, 2)
+        @pagy, @products = pagy(Product.send('pending'), items: ENV['ITEMS_PER_PAGE'])
+        @adopt_status = 'pending'
+      end
 
-    it 'should display logout link' do
-      render
-      expect(rendered).to have_link('Logout', href: destroy_admin_session_path)
-    end
-
-    it 'should display login information' do
-      render
-      expect(rendered).to have_text('Logged in as random@example.com')
+      it 'should not allow admin to see new product and destroy links when the product is adopted' do
+        render
+        expect(rendered).to have_no_link('Destroy')
+        expect(rendered).to have_no_link('New Product')
+      end
     end
   end
 


### PR DESCRIPTION
- Changed admin page header to include pending books.
- Removed cart from header for admins
- Removed 'Destroy' for adopted and pending books.
- Changed styles of button and display of login information.
- Removed 'Add to cart' button for admins.
- On logout, now it redirects to login page instead of root page.
- Added test cases for all the new features added.

Pending items:
- Change edit form like how Christa needs it.
- When Christa moves pending book back to available (because of incomplete payment), author information should be removed from adopter table which automatically unlinks the adopter from products table.
- Change look and feel of index and edit page if required.
- Add validations to new and edit forms to have dropdown for status or in-editable product and adopter fields.

